### PR TITLE
pandoc v1.17.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set v = "1.16.0.2" %}
+{% set v = "1.17.0.1" %}
 
 package:
   name: pandoc
@@ -7,13 +7,13 @@ package:
 source:
   fn:   pandoc-{{ v }}-amd64.deb                                                            # [linux64]
   url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-1-amd64.deb  # [linux64]
-  md5:  00e0b312e764ada376444fb5835d0574                                                    # [linux64]
+  md5:  827e87a4188d0ac49095835a3bf0a3c6                                                    # [linux64]
   fn:   pandoc-{{ v }}.pkg                                                                  # [osx]
   url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-osx.pkg      # [osx]
-  md5:  c0a3e7af327e33c58e81ee567655304d                                                    # [osx]
+  md5:  1321e443caf6a5a7b52098ebc5151090                                                    # [osx]
   fn:   pandoc-{{ v }}-windows.msi                                                          # [win]
   url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-windows.msi  # [win]
-  md5:  6be571c106d4099ca1066b8a9baa8f2b                                                    # [win]
+  md5:  ea2bb7f6c65012a865b33fe76f87e6f8                                                    # [win]
 
 requirements:
   run:


### PR DESCRIPTION
Includes 
https://github.com/jgm/pandoc/releases/tag/1.17
https://github.com/jgm/pandoc/releases/tag/1.17.0.1