### PR TITLE
Upgrade to pandoc 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About pandoc
 ============
 
-Home: http://johnmacfarlane.net/pandoc/
+Home: http://pandoc.org/
 
 Package license: GPL-2.0
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 if [ $(uname) == Linux ]; then
     ar vx pandoc*.deb
-    tar -xzvf data.tar.gz
+    tar --extract --xz --verbose --file=data.tar.xz
     mkdir -p $PREFIX/bin
     mv usr/bin/* $PREFIX/bin
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0" %}
+{% set version = "2.0.0.1" %}
 
 package:
   name: pandoc
@@ -6,14 +6,14 @@ package:
 
 source:
   fn: pandoc-{{ version }}-amd64.deb                                                                     # [linux64]
-  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-3-amd64.deb    # [linux64]
-  sha256: 381cde6bb2360bbcbf4ecac69eaec625f8858a8ee8cfa11b5d951e35c3fc92d9                               # [linux64]
+  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-amd64.deb    # [linux64]
+  sha256: e0d8941aa7310e7bdcac6cb425fa99e1630c45dd2f756a61d2c53bbc57da5555                               # [linux64]
   fn: pandoc-{{ version }}.pkg                                                                           # [osx]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg      # [osx]
-  sha256: a35aeee1d57bb6aa0271b5701637d3afc04d1dfca9a0368c2ef4778711ba1a60                               # [osx]
+  sha256: 9cddbe28b6eade1f760a7b6dc4e0d9f18ab0a63c64ec107bb2301f0f8ffa3e6b                               # [osx]
   fn: pandoc-{{ version }}-windows.msi                                                                   # [win]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-windows.msi    # [win]
-  sha256: 30fd7386cdc3fe17f91c545626999bd121a2ec5d77a26b6988291af8012262fc                               # [win]
+  sha256: 0b1d27bf68fbaf7a0454c91590ad5e2a044ab44b73917d9fba832ffa7f7127d2                               # [win]
 
 build:
    number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.19.2" %}
+{% set version = "2.0" %}
 
 package:
   name: pandoc
@@ -6,14 +6,14 @@ package:
 
 source:
   fn: pandoc-{{ version }}-amd64.deb                                                                     # [linux64]
-  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-amd64.deb    # [linux64]
-  sha256: 308fa08d427a2b49c6b4d1558884c8fad2f07684997232b4818b98cc7ca14392                               # [linux64]
+  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-3-amd64.deb    # [linux64]
+  sha256: 381cde6bb2360bbcbf4ecac69eaec625f8858a8ee8cfa11b5d951e35c3fc92d9                               # [linux64]
   fn: pandoc-{{ version }}.pkg                                                                           # [osx]
-  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-osx.pkg        # [osx]
-  sha256: ebf8af76d94a87803d938e18d1b6f2da472e610a73f48838932a808ca2593239                               # [osx]
+  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg      # [osx]
+  sha256: a35aeee1d57bb6aa0271b5701637d3afc04d1dfca9a0368c2ef4778711ba1a60                               # [osx]
   fn: pandoc-{{ version }}-windows.msi                                                                   # [win]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-windows.msi    # [win]
-  sha256: 63d26519adc2a86f71160058b8a03f2a4911064ef4b4ae3d3900c413e81beac0                               # [win]
+  sha256: 30fd7386cdc3fe17f91c545626999bd121a2ec5d77a26b6988291af8012262fc                               # [win]
 
 build:
    number: 0
@@ -29,7 +29,7 @@ test:
     - pandoc --version
 
 about:
-  home: http://johnmacfarlane.net/pandoc/
+  home: http://pandoc.org/
   license: GPL-2.0
   summary: 'Universal markup converter (repackaged binaries).'
 
@@ -37,3 +37,4 @@ extra:
   recipe-maintainers:
     - janschulz
     - ocefpaf
+    - dhimmel


### PR DESCRIPTION
Release notes at:
https://github.com/jgm/pandoc/releases/tag/2.0
http://pandoc.org/releases.html#pandoc-2.0-29-oct-2017