### PR TITLE
updated windows version to latest fixed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg  # [osx]
   sha256: a55c91f0bbb59246ac0ec841d68ac00b70e7e5a7af3f15c4fb25338fcfe1f0a7  # [osx]
 
-  fn: pandoc{{ version }}-1-windows-x86_64.msi  # [win]
+  fn: pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
   sha256: 76600c1e1f1096fbc871fe8f158355a1bbd303034ff33bec5117c9c4273fb715  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg  # [osx]
   sha256: a55c91f0bbb59246ac0ec841d68ac00b70e7e5a7af3f15c4fb25338fcfe1f0a7  # [osx]
 
+  fn: pandoc{{ version }}-1-windows-x86_64.msi  # [win]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
   sha256: 76600c1e1f1096fbc871fe8f158355a1bbd303034ff33bec5117c9c4273fb715  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg  # [osx]
   sha256: a55c91f0bbb59246ac0ec841d68ac00b70e7e5a7af3f15c4fb25338fcfe1f0a7  # [osx]
 
-  fn: pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
+  fn: pandoc-{{ version }}-windows-x86_64.msi  # [win]
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
   sha256: 76600c1e1f1096fbc871fe8f158355a1bbd303034ff33bec5117c9c4273fb715  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,11 @@ source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-macOS.pkg  # [osx]
   sha256: a55c91f0bbb59246ac0ec841d68ac00b70e7e5a7af3f15c4fb25338fcfe1f0a7  # [osx]
 
-  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-windows-x86_64.msi  # [win]
-  sha256: d11f3e08156c0544417af6a44cb44af8e5c17c0475663bebc046d395de4916dd  # [win]
+  url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-1-windows-x86_64.msi  # [win]
+  sha256: 76600c1e1f1096fbc871fe8f158355a1bbd303034ff33bec5117c9c4273fb715  # [win]
 
 build:
-   number: 0
+   number: 1
 
 requirements:
   run:


### PR DESCRIPTION
There was a problem with some o fthe the 2.2.2 installers, see [issue](https://github.com/jgm/pandoc/issues/4775) and [discussion](https://groups.google.com/forum/#!topic/pandoc-discuss/UDIxM2k5ZZU).

2.2.2-1 fixes that.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
