### PR TITLE
Remove hash from package name

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,14 +8,19 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_target_platformlinux-64:
+        CONFIG: linux_target_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8
   timeoutInMinutes: 360
 
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+    displayName: Manage disk space
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
@@ -27,6 +32,7 @@ jobs:
   - script: |
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: macOS-10.14
   strategy:
     matrix:
-      osx_:
-        CONFIG: osx_
+      osx_target_platformosx-64:
+        CONFIG: osx_target_platformosx-64
         UPLOAD_PACKAGES: 'True'
     maxParallel: 8
   timeoutInMinutes: 360
@@ -20,6 +20,7 @@ jobs:
       export CI=azure
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_:
-        CONFIG: win_
+      win_target_platformwin-64:
+        CONFIG: win_target_platformwin-64
         UPLOAD_PACKAGES: 'True'
     maxParallel: 4
   timeoutInMinutes: 360
@@ -93,14 +93,16 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        validate_recipe_outputs "pandoc-feedstock"
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        upload_package --validate --feedstock-name="pandoc-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
@@ -1,0 +1,8 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-ppc64le
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -2,3 +2,7 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/osx_target_platformosx-64.yaml
+++ b/.ci_support/osx_target_platformosx-64.yaml
@@ -8,3 +8,5 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+target_platform:
+- osx-64

--- a/.ci_support/win_target_platformwin-64.yaml
+++ b/.ci_support/win_target_platformwin-64.yaml
@@ -2,5 +2,5 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-comp7
+target_platform:
+- win-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -30,11 +30,12 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "pandoc-feedstock"
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="pandoc-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -13,6 +13,10 @@ PROVIDER_DIR="$(basename $THISDIR)"
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -63,12 +67,14 @@ docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
+           -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -47,10 +47,10 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "pandoc-feedstock"
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="pandoc-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+env:
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "FnMa+oIk/GreZwQfI0ybIn2g9B0jIHYxRJ5TDOVv04xf7uFbbzei8JwMLQSD/dlJBNCf7eTxoHVNFL1+/oQvf1oh83tRmtkSketkfgOC/CV/nP0uJcyb60JRxtWOcmjHl+E+5WgOS+zaha9SIfB6pc/GwmIjsHfUnwh2o8fQHvopdHyliVwRN6Ji5++pVxleXwwtBa/2PYhUgzGJKWfLAJ1o5W89O8OiNiRrwMkR8Y0X3SO8ZXAAZk/E+6590yfSzltKLZmWe++aJQJoSq3YsrSUUhLZeRMsQ7hQ/+0BAY4pE2QWADZEGaPDI76AQzWFnkTTxmnucw1PJH3ZVFtI9ryaw4oq3gFnExvo/HCVYl/MtO9ZL4dB2YYExvgw2gQnd7YL/Z1KgbLGmoiaZFFegZc8qmJ5dzpdwZoMi3LOkcXnTOtjRxEZHGp5q4L7oC10PXPCEcm9FQbl0SnxaP0KP1g4npg4XSV97kOOAE2KKCvd66XWbzgvU5yCmx0T6AsQd4/hWE5B61OJskGfHEIsa7jRmOeYcwyuX7Ld+wVi2XvwEGdIXyOO3I01lhZ/EtIuJCRHtXkf2Nxde8T93Aucbv5Gncwq7SS7ObHNrkgS4qDhr8oKrjL0FRSmyqHYM9AACcfnDUR9JQvV/c6kSPsLcAGmSkcbN95mrd6PruAGr0A="
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -3,19 +3,28 @@ About pandoc
 
 Home: http://pandoc.org/
 
-Package license: GPL-2.0
+Package license: GPL-2.0-or-later
 
-Feedstock license: BSD 3-Clause
+Feedstock license: BSD-3-Clause
 
 Summary: Universal markup converter (repackaged binaries)
 
+Pandoc is a Haskell library for converting from one markup format to
+another, and a command-line tool that uses this library.
 
 
 Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/pandoc-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/pandoc-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -29,36 +38,37 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_ppc64le_target_platformlinux-ppc64le</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4456&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_target_platformlinux-ppc64le" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx</td>
+              <td>linux_target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4456&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=linux&configuration=linux_target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win</td>
+              <td>osx_target_platformosx-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4456&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=win&configuration=win_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=osx&configuration=osx_target_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_target_platformwin-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4456&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pandoc-feedstock?branchName=master&jobName=win&configuration=win_target_platformwin-64" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,4 +6,5 @@ appveyor:
     BINSTAR_TOKEN: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 provider:
   win: azure
+  linux_ppc64le: default
 conda_forge_output_validation: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,8 +4,3 @@ IFS=$'\n\t'
 
 mkdir -p ${PREFIX}/bin
 mv bin/* ${PREFIX}/bin
-
-# The pandoc binary was built against libffi 3.2 but is compatible with 3.3 which uses a different SONAME
-if [[ ${target_platform} =~ .*linux-ppc64le.* ]]; then
-    patchelf --replace-needed libffi.so.6 libffi.so.7  ${PREFIX}/bin/pandoc
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ build:
 {% if ARCH == "ppc64le" %}
 requirements:
   build:
-    - patchelf
     # we do not actually need a compiler but want the
     # sysroot for link checking and the run_exports
     # avoid {{ compiler('c') }} which adds unneeded hashes on all platforms
@@ -42,7 +41,7 @@ requirements:
   host:
     - gmp 6.1.2
     - zlib 1.2.11
-    - libffi 3.3
+    - libffi 3.2
 {% endif %}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,10 @@ build:
 requirements:
   build:
     - patchelf
-    - {{ compiler('c') }}
+    # we do not actually need a compiler but want the
+    # sysroot for link checking and the run_exports
+    # avoid {{ compiler('c') }} which adds unneeded hashes on all platforms
+    - gcc_linux-ppc64le
   host:
     - gmp 6.1.2
     - zlib 1.2.11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ source:
   sha256: 5a9818493f8b14821c5fb44234c898f776faf011089dc77e1dcf6ba3e51e0a81  # [ppc64le]
 
 build:
-  number: 0
+  number: 0  # [ppc64le]
+  number: 1  # [not ppc64le]
   binary_relocation: false  # [osx]
   missing_dso_whitelist:
     - /usr/lib/libiconv.2.dylib  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
 
 about:
   home: http://pandoc.org/
-  license: GPL-2.0
+  license: GPL-2.0-or-later
   license_family: GPL
   license_file: LICENSE
   summary: Universal markup converter (repackaged binaries)


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

#71  accidentally introduced an un-needed hash into the package name.  This change removes then and enabled the ppc64le build.