### PR TITLE
Remove dhimmel as a recipe-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dhimmel @jankatins @kiwi0fruit @ocefpaf
+* @jankatins @kiwi0fruit @ocefpaf

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@dhimmel](https://github.com/dhimmel/)
 * [@jankatins](https://github.com/jankatins/)
 * [@kiwi0fruit](https://github.com/kiwi0fruit/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,5 +64,4 @@ extra:
   recipe-maintainers:
     - jankatins
     - ocefpaf
-    - dhimmel
     - kiwi0fruit


### PR DESCRIPTION
I'm not confident that I have the expertise for this role. I get a lot of notifications related to this that I don't want.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
-->