### PR TITLE
Revert "repack pandoc 2.2.1 RPM from Fedora on ppc64le"

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,3 @@
-c_compiler:
-- gcc
-c_compiler_version:
-- '9'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,9 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-c_compiler:
-- clang
-c_compiler_version:
-- '11'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,3 @@
-c_compiler:
-- vs2017
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,8 +4,3 @@ IFS=$'\n\t'
 
 mkdir -p ${PREFIX}/bin
 mv bin/* ${PREFIX}/bin
-
-# The pandoc binary was built against libffi 3.2 but is compatible with 3.3 which uses a different SONAME
-if [[ ${target_platform} =~ .*linux-ppc64le.* ]]; then
-    patchelf --replace-needed libffi.so.6 libffi.so.7  ${PREFIX}/bin/pandoc
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,7 @@
 
 package:
   name: pandoc
-  version: {{ version }}  # [not ppc64le]
-  version: 2.2.1  # [ppc64le]
+  version: {{ version }}
 
 source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-linux-amd64.tar.gz  # [linux64]
@@ -16,10 +15,6 @@ source:
   url: https://github.com/jgm/pandoc/releases/download/{{ version }}/pandoc-{{ version }}-windows-x86_64.msi  # [win]
   sha256: 16265e7d0f04b3f8864f447d7692544ce7b1efeb0aa13a5f89f5026683a428d2  # [win]
 
-  # repackage the RPM built for EPEL
-  url: https://copr-be.cloud.fedoraproject.org/results/petersen/pandoc/epel-7-ppc64le/00770404-pandoc/pandoc-2.2.1-1.el7.ppc64le.rpm  # [ppc64le]
-  sha256: 5a9818493f8b14821c5fb44234c898f776faf011089dc77e1dcf6ba3e51e0a81  # [ppc64le]
-
 build:
   number: 0
   binary_relocation: false  # [osx]
@@ -27,19 +22,6 @@ build:
     - /usr/lib/libiconv.2.dylib  # [osx]
     - /usr/lib/libz.1.dylib  # [osx]
     - /usr/lib/libcharset.1.dylib  # [osx]
-
-# The pandoc binary from the RPM depends on libgmp, libz and libffi and system libraries.
-# Add these as host requirements to pick up the correct run_exports
-{% if ARCH == "ppc64le" %}
-requirements:
-  build:
-    - patchelf
-    - {{ compiler('c') }}
-  host:
-    - gmp 6.1.2
-    - zlib 1.2.11
-    - libffi 3.3
-{% endif %}
 
 test:
   commands:


### PR DESCRIPTION
This reverts commit 422f9b56da8a0c337df04e391f3fd51e65e2f582.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

c.f. #71, #72